### PR TITLE
perf: reduce excessive allocations

### DIFF
--- a/src/main/java/kr/hahaha98757/zombiesaddon/utils/Utils.java
+++ b/src/main/java/kr/hahaha98757/zombiesaddon/utils/Utils.java
@@ -108,7 +108,12 @@ public class Utils {
     }
 
     public static boolean isNotZombies() {
-        return getScoreboard() == null;
+        if (mc.theWorld == null || mc.thePlayer == null) return true;
+
+        Scoreboard scoreboard = mc.thePlayer.getWorldScoreboard();
+        ScoreObjective scoreObjective = scoreboard.getObjectiveInDisplaySlot(1);
+
+        return scoreObjective == null || !EnumChatFormatting.getTextWithoutFormattingCodes(scoreObjective.getDisplayName()).equals("ZOMBIES");
     }
 
     public static boolean isNotPlayZombies() {

--- a/src/main/java/kr/hahaha98757/zombiesaddon/utils/Utils.java
+++ b/src/main/java/kr/hahaha98757/zombiesaddon/utils/Utils.java
@@ -87,7 +87,6 @@ public class Utils {
     }
 
     private static HashMap<Integer, String> getScoreboard() {
-        HashMap<Integer, String> scoreboards = new HashMap<>();
         if (mc.theWorld == null || mc.thePlayer == null) return null;
 
         Scoreboard scoreboard = mc.thePlayer.getWorldScoreboard();
@@ -95,6 +94,7 @@ public class Utils {
 
         if (scoreObjective == null || !EnumChatFormatting.getTextWithoutFormattingCodes(scoreObjective.getDisplayName()).equals("ZOMBIES")) return null;
 
+        HashMap<Integer, String> scoreboards = new HashMap<>();
         for (Score score : scoreboard.getSortedScores(scoreObjective))
             scoreboards.put(score.getScorePoints(), EnumChatFormatting.getTextWithoutFormattingCodes(ScorePlayerTeam.formatPlayerName(scoreboard.getPlayersTeam(score.getPlayerName()), score.getPlayerName())).replaceAll("[^A-Za-z0-9가-힣:_.,/\\s]", "").trim());
         return scoreboards;


### PR DESCRIPTION
For every updated entity, it runs Utils#isNotZombies which does a lot of String replace & formatting as well as creating new HashMaps.

Especially in Zombies this can easily allocate 300+ MB/s do to how many entities spawn.

To quickly address this, there are 2 changes:
- 1. Defer HashMap instantiation to only when actually needed
- 2. Avoid expensive String replacements in Utils#isNotZombies since it doesn't actually need the scoreboard information, it only cares about whether it exists.

To further improve this, it would be best to move this into ClientTick instead of LivingUpdate and run this once every 10 or 20 ticks, as well as using a cached HashMap.